### PR TITLE
fix: run eslint from PATH

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -141,9 +141,7 @@ export async function run(verb: string, files: string[]): Promise<boolean> {
     case 'lint':
     case 'check': {
       try {
-        await execa('node', ['./node_modules/eslint/bin/eslint', ...flags], {
-          stdio: 'inherit',
-        });
+        await execa('eslint', flags, {stdio: 'inherit'});
         return true;
       } catch (e) {
         return false;
@@ -152,13 +150,7 @@ export async function run(verb: string, files: string[]): Promise<boolean> {
     case 'fix': {
       const fixFlag = options.dryRun ? '--fix-dry-run' : '--fix';
       try {
-        await execa(
-          'node',
-          ['./node_modules/eslint/bin/eslint', fixFlag, ...flags],
-          {
-            stdio: 'inherit',
-          }
-        );
+        await execa('eslint', [fixFlag, ...flags], {stdio: 'inherit'});
         return true;
       } catch (e) {
         console.error(e);


### PR DESCRIPTION
Rationale:
- npm and Yarn both put (a directory containing) the eslint binary on PATH during "npm run foo", so take advantage of that to invoke eslint in a way that is compatible with Yarn workspaces.
- (Node that `node_modules/eslint/...` may not exist, because the module may have been installed in another `node_modules` further up the filesystem tree. Yarn does ensure that the binary gets symlinked into `node_modules/.bin`.)
- This should fix issue #490.